### PR TITLE
Add a backward compatible way to detect the screenshots directory in XCode6 / CoreSimulator.

### DIFF
--- a/motion-screenshots.gemspec
+++ b/motion-screenshots.gemspec
@@ -19,8 +19,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "motion-cocoapods", ">= 1.4.0"
-  spec.add_dependency "motion-env", ">= 0.0.3"
-
+  spec.add_dependency "motion-cocoapods", ">= 1.7.0"
+  spec.add_dependency "motion-env", ">= 0.0.4"
+  spec.add_dependency "plist", ">= 3.1.0"
+  
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
This PR will fix #3 by looking for the CoreSimulator directory introduced in XC6.
If found it..:
- will search for the newest app installation
- to determine the simulator UUID from it
- parse the BackBoard/applicationState.plist to determine the correct sandbox directory
- use that path to copy the screenshots from

If not found it will simply use the old method to detect the correct directory.
This requires plutil as well as the plist gem but I don't think they should pose big problems on a Mac.